### PR TITLE
Event sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,11 +103,6 @@ document.addEventListener('DOMContentLoaded', event => {
 
 The `ChipReaderWatcher` is a singleton class which handles the USB device monitoring and permissions handling. There can be only one `ChipReaderWatcher` instance created within a `window` scope, so the library instantiates the class during import and preserves a single instance for all imports.
 
-#### Properties
-| Name | Usage |
-| ---- | ----- |
-| `isConnected: boolean` | Indicates whether a Chip Reader device is connected |
-
 #### Methods
 | Name | Usage |
 | ---- | ----- |

--- a/src/chipReaderWatcher.ts
+++ b/src/chipReaderWatcher.ts
@@ -9,7 +9,6 @@ const CHIP_READER_PRODUCT_ID = 0x2490
 export class ChipReaderWatcher extends USBDevice {
   private onConnectEvent = new TypedEvent<ChipReader>()
   private onDisconnectEvent = new TypedEvent<WebUSBDevice>()
-  private connectedChipReaders: Array<ChipReader> = []
 
   constructor () {
     super(CHIP_READER_VENDOR_ID, CHIP_READER_PRODUCT_ID)
@@ -19,16 +18,10 @@ export class ChipReaderWatcher extends USBDevice {
     await Promise.all(this.connectedDevices.map(d => this.disconnected(d)))
   }
 
-  get isConnected () {
-    return this.connectedChipReaders.length > 0
-  }
-
-  getConnectedChipReaders () {
-    return this.connectedChipReaders.slice(0)
-  }
-
   onConnect (listener: Listener<ChipReader>): Disposable {
-    return this.onConnectEvent.on(listener)
+    const unsubscribe = this.onConnectEvent.on(listener)
+    this.initialize()
+    return unsubscribe
   }
 
   private onDisconnect (listener: Listener<WebUSBDevice>) {
@@ -39,7 +32,6 @@ export class ChipReaderWatcher extends USBDevice {
     await super.connected(device)
     const chipReader = new ChipReader(device, (l: Listener<WebUSBDevice>) => this.onDisconnect(l))
     await chipReader.claimed
-    this.connectedChipReaders.push(chipReader)
     this.onConnectEvent.emit(chipReader)
   }
 

--- a/src/usbDevice.ts
+++ b/src/usbDevice.ts
@@ -4,22 +4,29 @@ import { WebUSBDevice, USBConnectionEvent } from '../types/w3c-web-usb'
 export class USBDevice {
   private readonly vendorId: number
   private readonly productId: number
+  private initialized: boolean = false
   protected connectedDevices: Array<WebUSBDevice> = []
 
   constructor (vendorId: number, productId: number) {
     this.vendorId = vendorId
     this.productId = productId
+  }
 
-    if (typeof navigator.usb === 'undefined') {
-      if (typeof window.node_usb === 'undefined') {
-        throw new Error('Web-USB not supported in this browser')
+  protected initialize () {
+    if (!this.initialized) {
+      if (typeof navigator.usb === 'undefined') {
+        if (typeof window.node_usb === 'undefined') {
+          throw new Error('Web-USB not supported in this browser')
+        }
+      } else {
+        navigator.usb.addEventListener('connect', event => { void this.attached(event as USBConnectionEvent) })
+        navigator.usb.addEventListener('disconnect', event => { void this.detached(event as USBConnectionEvent) })
       }
-    } else {
-      navigator.usb.addEventListener('connect', event => { void this.attached(event as USBConnectionEvent) })
-      navigator.usb.addEventListener('disconnect', event => { void this.detached(event as USBConnectionEvent) })
-    }
 
-    void this.checkDevices()
+      void this.checkDevices()
+
+      this.initialized = true
+    }
   }
 
   async start () {


### PR DESCRIPTION
Postpones initialization of the USB device until the first `onConnect` listener is bound.  This also removes the `isConnected` property and `getConnectedChipReaders` method.

@ish2028, this is why we can't have nice things 😠